### PR TITLE
fcntl import breaks portability with Windows

### DIFF
--- a/src/filester/__init__.py
+++ b/src/filester/__init__.py
@@ -1,11 +1,9 @@
 """Generic, file-based utilities and helpers.
 
 """
-from typing import AnyStr, Iterator, Optional, Union
-import fcntl
+from typing import Iterator, Optional, Union
 import fnmatch
 import hashlib
-import io
 import os
 import re
 import shutil


### PR DESCRIPTION
### Summary
* Remove stray imports (`fcntl`).

### Pre-Review Checks
- [ ] `make tests` completes successfully
- [ ] [Reviewed and commented](https://leeorengel.com/review-comment-your-pull-requests/) on PR
